### PR TITLE
Modified OCP 4.4 image paths

### DIFF
--- a/inventory/group_vars/all/software/coreos.yml
+++ b/inventory/group_vars/all/software/coreos.yml
@@ -22,13 +22,13 @@ coreos_versions:
     vmware_ova_url:          '{{ coreos_url_prefix }}/4.3/4.3.0/rhcos-4.3.0-x86_64-vmware.ova'
     sha256sum_url:           '{{ coreos_url_prefix }}/4.3/4.3.0/sha256sum.txt'
   4.4.0:
-    installer_initramfs_url: '{{ coreos_url_prefix }}/4.4/latest/rhcos-4.4.0-rc.1-x86_64-installer-initramfs.x86_64.img'
-    installer_kernel_url:    '{{ coreos_url_prefix }}/4.4/latest/rhcos-4.4.0-rc.1-x86_64-installer-kernel-x86_64'
-    metal_bios_url:          '{{ coreos_url_prefix }}/4.4/latest/rhcos-4.4.0-rc.1-x86_64-metal.x86_64.raw.gz'
-    openstack_qcow2_url:     '{{ coreos_url_prefix }}/4.4/latest/rhcos-4.4.0-rc.1-x86_64-openstack.x86_64.qcow2.gz'
-    qemu_qcow2_url:          '{{ coreos_url_prefix }}/4.4/latest/rhcos-4.4.0-rc.1-x86_64-qemu.x86_64.qcow2.gz'
-    vmware_ova_url:          '{{ coreos_url_prefix }}/4.4/latest/rhcos-4.4.0-rc.1-x86_64-vmware.x86_64.ova'
-    sha256sum_url:           '{{ coreos_url_prefix }}/4.4/latest/sha256sum.txt'
+    installer_initramfs_url: '{{ coreos_url_prefix }}/4.4/4.4.3/rhcos-4.4.3-x86_64-installer-initramfs.x86_64.img'
+    installer_kernel_url:    '{{ coreos_url_prefix }}/4.4/4.4.3/rhcos-4.4.3-x86_64-installer-kernel-x86_64'
+    metal_bios_url:          '{{ coreos_url_prefix }}/4.4/4.4.3/rhcos-4.4.3-x86_64-metal.x86_64.raw.gz'
+    openstack_qcow2_url:     '{{ coreos_url_prefix }}/4.4/4.4.3/rhcos-4.4.3-x86_64-openstack.x86_64.qcow2.gz'
+    qemu_qcow2_url:          '{{ coreos_url_prefix }}/4.4/4.4.3/rhcos-4.4.3-x86_64-qemu.x86_64.qcow2.gz'
+    vmware_ova_url:          '{{ coreos_url_prefix }}/4.4/4.4.3/rhcos-4.4.3-x86_64-vmware.x86_64.ova'
+    sha256sum_url:           '{{ coreos_url_prefix }}/4.4/4.4.3/sha256sum.txt'
 
 coreos:
   installer_initramfs_url: '{{ coreos_versions[openshift_install_config.version].installer_initramfs_url }}'


### PR DESCRIPTION
OCP 4.4 is now GA, and the image names have changed.