### PR TITLE
Download retry

### DIFF
--- a/roles/clients/tasks/main.yml
+++ b/roles/clients/tasks/main.yml
@@ -10,6 +10,7 @@
     url: '{{ openshift_installer.archive_url }}'
     dest: '{{ helper.install_bin_dir }}/{{ openshift_installer.archive_url | basename }}'
     checksum: 'sha256:{{ openshift_installer.sha256sum_url }}'
+  retries: 3
 
 - name: Extract openshift-install
   unarchive:
@@ -22,6 +23,7 @@
     url: '{{ openshift_client.archive_url }}'
     dest: '{{ helper.install_bin_dir }}/{{ openshift_client.archive_url | basename }}'
     checksum: 'sha256:{{ openshift_client.sha256sum_url }}'
+  retries: 3
 
 - name: Extract oc client
   unarchive:

--- a/roles/openshift_common/tasks/download_coreos.yml
+++ b/roles/openshift_common/tasks/download_coreos.yml
@@ -18,6 +18,7 @@
     url: '{{ download_coreos_url }}'
     dest: '{{ helper.images_dir }}/{{ download_coreos_url | basename }}'
     checksum: '{{ download_coreos_checksum }}'
+  retries: 3
 
 - name: Set image filename
   set_fact:

--- a/roles/openshift_common/tasks/ensure_pxe_prereqs.yml
+++ b/roles/openshift_common/tasks/ensure_pxe_prereqs.yml
@@ -21,6 +21,7 @@
     url: '{{ item }}'
     dest: '{{ helper.web_cluster_dir }}/{{ item | basename }}'
     checksum: '{{ coreos.checksum }}'
+  retries: 3
   with_items:
     - '{{ coreos.installer_initramfs_url }}'
     - '{{ coreos.installer_kernel_url }}'


### PR DESCRIPTION
Downloading prerequisite files such as ISO or initramfs temporarily fails due to network issues, the download site unstable, or for some reason once in a while, so why don't we add `retries` for each `get_url` tasks?