### PR TITLE
Add machineNetwork key to install-config

### DIFF
--- a/files/common/install-config.yaml.sample
+++ b/files/common/install-config.yaml.sample
@@ -18,6 +18,8 @@ networking:
   networkType: OVNKubernetes
   serviceNetwork:
   - 172.30.0.0/16
+  machineNetwork:
+  - 10.0.0.0/16
 platform:
   # Uncomment this if installing to Bare metal, Libvirt, and oVirt target platforms
 #  none: {}


### PR DESCRIPTION
When using a proxy to connect to the internet, MachineNetwork must be properly configured so that OpenShift can automatically add it to NO_PROXY. Otherwise machineNetwork defaults to 10.0.0.0/16 and inter-node traffic will try to use the proxy. This results in the nodes being unable to communicate with each other, and the API server will fail to start.