### PR TITLE
Several files need specific modes that are not ensured by default

### DIFF
--- a/roles/dhcp_server/tasks/main.yml
+++ b/roles/dhcp_server/tasks/main.yml
@@ -18,6 +18,7 @@
   template:
     src: '{{ item.src }}'
     dest:  '{{ item.dest }}'
+    mode: 0644
   with_items:
     - { src: dnsmasq.openshift-auto-upi.dhcp.conf, dest: /etc/dnsmasq.d }
     - { src: dnsmasq.openshift-auto-upi.hostsfile, dest: /etc }

--- a/roles/dns_server/tasks/main.yml
+++ b/roles/dns_server/tasks/main.yml
@@ -18,6 +18,7 @@
   template:
     src: '{{ item.src }}'
     dest:  '{{ item.dest }}'
+    mode: 0644
   with_items:
     - { src: dnsmasq.openshift-auto-upi.dns.conf, dest: /etc/dnsmasq.d }
     - { src: dnsmasq.openshift-auto-upi.addnhosts, dest: /etc }

--- a/roles/openshift_common/tasks/ensure_pxe_prereqs.yml
+++ b/roles/openshift_common/tasks/ensure_pxe_prereqs.yml
@@ -4,6 +4,7 @@
     owner: '{{ ansible_real_user_id | int }}'
     group: '{{ ansible_real_group_id | int }}'
     state: directory
+    mode: 0755
   with_items:
     - '{{ helper.web_cluster_dir }}'
   become: True
@@ -24,6 +25,7 @@
     url: '{{ item.url }}'
     dest: '{{ helper.web_cluster_dir }}/{{ item.url | basename }}'
     checksum: 'sha256:{{ item.checksum }}'
+    mode: 0644
   retries: 3
   with_items:
     - url: '{{ coreos.installer_initramfs_url }}'
@@ -37,6 +39,7 @@
   file:
     path: '{{ item }}'
     state: directory
+    mode: 0755
   with_items:
     - '{{ helper.tftp_dir }}'
   become: True
@@ -47,6 +50,7 @@
     owner: '{{ ansible_real_user_id | int }}'
     group: '{{ ansible_real_group_id | int }}'
     state: directory
+    mode: 0755
   with_items:
     - '{{ helper.tftp_cluster_dir }}'
   become: True
@@ -55,9 +59,11 @@
   file:
     dest: '{{ helper.tftp_cluster_dir }}/pxelinux.cfg'
     state: directory
+    mode: 0755
 
 - name: Create pxelinux.cfg configs
   template:
     src: files/boot/pxe/pxelinux.cfg/menu.cfg
     dest: '{{ helper.tftp_cluster_dir }}/pxelinux.cfg/01-{{ item.macaddr | regex_replace(":", "-") }}'
+    mode: 0644
   with_items: '{{ openshift_cluster_hosts }}'

--- a/roles/pxe_server/tasks/main.yml
+++ b/roles/pxe_server/tasks/main.yml
@@ -27,6 +27,7 @@
   file:
     path: '{{ item }}'
     state: directory
+    mode: 0755
   with_items:
     - '{{ helper.tftp_dir }}'
   become: True
@@ -37,6 +38,7 @@
     owner: '{{ ansible_real_user_id | int }}'
     group: '{{ ansible_real_group_id | int }}'
     state: directory
+    mode: 0755
   become: True
 
 - name: Install syslinux

--- a/roles/web_server/tasks/main.yml
+++ b/roles/web_server/tasks/main.yml
@@ -41,4 +41,5 @@
     owner: '{{ ansible_real_user_id | int }}'
     group: '{{ ansible_real_group_id | int }}'
     state: directory
+    mode: 0755
   become: True


### PR DESCRIPTION
I used this repo with an account with umask of 0027 instead of the default 0022 and that caused lots of problems with file modes. This patch adds the mode parameter with the correct mode to several files that need specific permissions.